### PR TITLE
Closes KAD-669 - remove wildfly & cdi modules and supported environments

### DIFF
--- a/docs/user-guide/getting-started/supportedEnvironments.md
+++ b/docs/user-guide/getting-started/supportedEnvironments.md
@@ -11,7 +11,6 @@ sidebar_position: 2
 - or PostgresSQL 14.7
 ### Container/Application Server (optional)
   - Embedded Tomcat of Spring Boot 
-  - or Wildfly Application Server
 ### Web Browser (optional)
   - Google Chrome (latest 2 versions)
   - or Mozilla Firefox (latest 2 versions)

--- a/docs/user-guide/reference/modules.md
+++ b/docs/user-guide/reference/modules.md
@@ -11,14 +11,11 @@ Different functionality of KADAI can be found in different modules. In the follo
 - **kadai-core** provides the main functionality of KADAI. You can read more about kadai-core [here](../core-concepts/javaApiUsage)
 - **kadai-spring** configures Spring so that KADAI can be easily integrated
 - **kadai-spring-example** provides an example usage of kadai-spring
-- **kadai-cdi** uses dependency injection of java(CDI) for configuring KADAI
-- **kadai-cdi-example** provides an example usage of kadai-cdi
 
 ## rest
 
 - **kadai-rest-spring** embends KADAI in a spring-boot application. It exposes the Java API by setting up a corresponding REST-API
 - **kadai-rest-spring-example-boot** provides an example application that uses kadai-rest-spring
-- **kadai-rest-spring-example-wildfly** provides an example application that can be deployed on a Wildfly server
 
 ## history
 


### PR DESCRIPTION
This needs to wait until `v9.*.*` is finalized and `v10.0.*` is released.