### PR TITLE
Add Declarations

### DIFF
--- a/docs/user-guide/declarations/_category_.json
+++ b/docs/user-guide/declarations/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Declarations",
+  "position": 8,
+  "link": {
+    "type": "generated-index",
+    "description": "Declarations about the KADAI project"
+  }
+}

--- a/docs/user-guide/declarations/dataPrivacy.md
+++ b/docs/user-guide/declarations/dataPrivacy.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 2
+---
+
+# Data Privacy
+
+KADAI provides authentication and authorization features that are designed to protect the privacy and security of personal data (see [Security and Permissions](../core-concepts/securityAndPermissions.md) and [Security Configuration](../configuration/security.md)). The host of KADAI is responsible for complying with applicable data protection laws and their internal data privacy policies when using KADAI. We strongly recommend keeping the SecurityEnabled flag enabled for any KADAI instance handling sensitive data.

--- a/docs/user-guide/declarations/export.md
+++ b/docs/user-guide/declarations/export.md
@@ -1,0 +1,11 @@
+---
+sidebar_position: 4
+---
+
+# Export Formats
+
+KADAI is a free and open-source software and can run on your server with all the data under your ownership.
+
+As the host of KADAI, you can export all the data from the [database](../configuration/database.md) using the open query language SQL or database dumps, as specified by the respective database providers.
+
+The schema of the data model is visualized [here](../reference/dataModel.md).

--- a/docs/user-guide/declarations/removal.md
+++ b/docs/user-guide/declarations/removal.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 5
+---
+
+# Removal
+
+If you no longer wish to use KADAI, simply remove the library components from your application. KADAI does not leave a record of its use.

--- a/docs/user-guide/declarations/trackingAndAds.md
+++ b/docs/user-guide/declarations/trackingAndAds.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 3
+---
+
+# Freedom of Tracking and Advertising
+
+## Advertising
+
+KADAI will never have advertising for 3rd parties.
+
+## Tracking
+
+KADAI does not utilize any tracking mechanisms.
+
+Should any tracking features be introduced in the future, these will only be activated with explicit user consent and never without solicitation.

--- a/docs/user-guide/declarations/updatePolicies.md
+++ b/docs/user-guide/declarations/updatePolicies.md
@@ -1,0 +1,23 @@
+---
+sidebar_position: 1
+---
+
+# Update Policies
+
+KADAI publishes multiple releases each year. There is no specific release cycle.
+Our aim is to provide updates in line with the latest stable [Spring Boot releases](https://github.com/spring-projects/spring-boot/releases) to ensure compatibility and keep up to date.
+
+New versions will be announced on the [GitHub Releases](https://github.com/kadai-io/kadai/releases) page.
+
+## Security Updates
+
+KADAI uses Dependabot with GitHub Actions to automatically obtain security updates from dependencies on a daily basis.
+The tool creates pull requests, which we monitor on workdays and merge promptly.
+
+Security vulnerabilities found in KADAI itself are patched as soon as they become known to us.
+
+If you believe you have found a security vulnerability, please contact [kadai@envite.de](mailto:kadai@envite.de) to disclose it.
+
+Non-critical security vulnerabilities can also be reported via [GitHub Issues](https://github.com/kadai-io/kadai/issues).
+
+Since the software is open source, security updates can also be integrated at any time via pull requests.

--- a/docs/user-guide/reference/modules.md
+++ b/docs/user-guide/reference/modules.md
@@ -4,7 +4,11 @@ sidebar_position: 4
 
 # Modules
 
-Different functionality of KADAI can be found in different modules. In the following article, the relevant modules for external usage are explained. The modules for internal use only are left out of the article. 
+KADAI is highly modular software.
+It's up to you which modules you want to use.
+The only required module is **kadai-core**.
+
+Note: Only modules that are relevant for external use are explained here. Internal modules, such as those for logging, testing and configuration, have been omitted.
 
 ## lib
 


### PR DESCRIPTION
The Blue Angel certification requires declarations about user autonomy ([PDF](https://produktinfo.blauer-engel.de/uploads/criteriafile/de/171/DE-UZ%20215-202001-de%20Kriterien-V4.pdf)). As KADAI is free and open-source software, users are already autonomous. However, it doesn't hurt to add some explicit declarations to the KADAI documentation.

I took inspiration for some of these declarations from the already Blue Angel certified *Green Metrics Tool*: https://docs.green-coding.io/docs/declarations/.

This is a proposal. Let me know what you think.